### PR TITLE
Update to actions/upload-artifact@v3

### DIFF
--- a/.github/workflows/build_docker_on_commit.yml
+++ b/.github/workflows/build_docker_on_commit.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Save Docker image
       run: docker save --output image.tar "${IMAGE_TAG}"
     - name: Upload Docker image
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3 # Updated to v3
       with:
         name: docker-image
         path: image.tar


### PR DESCRIPTION
Current error:
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/