### PR TITLE
Add ability to configure process user at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.11-slim
 
+# Backwards compatible defaults
+ENV USER=root
+ENV GROUPNAME=root
+ENV UID=0
+ENV GID=0
+
 SHELL ["/bin/bash", "-ec"]
 
 RUN apt update && apt install --no-install-recommends -y bluez build-essential
@@ -9,4 +15,6 @@ RUN python3 -m venv /opt/venv && \
 	pip install --upgrade --extra-index-url=https://www.piwheels.org/simple pip TheengsGateway==1.5.0
 
 COPY chroot /
-CMD source /opt/venv/bin/activate && exec /opt/venv/start.sh
+CMD (getent group "${GROUPNAME}" || groupadd -g "${GID}" "${GROUPNAME}") && \
+    (getent passwd "${USER}" || useradd -u "${UID}" -g "${GID}" -m "${USER}") && \
+    su -l -s "/bin/bash" -c "source /opt/venv/bin/activate && exec /opt/venv/start.sh" "${USER}"


### PR DESCRIPTION
I'm very interested in running this container, but I would prefer not to run it as the root user. To that end, I'm proposing to modify the Dockerfile to allow the users to specify the user details at runtime.

The change in this PR introduces 4 new environment variables to control username, group name, user ID and group ID. The default values of these variables configure the root user to keep backwards compatibility for people already running the container.

In addition, the command that is executed when the container starts is extended to:
- check if the defined group and user already exist, if not they are created;
- switch from the root user to the new user (which could still be root) before executing the theengs gateway.