### PR TITLE
Add DISCOVERY_DIAGNOSTIC environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ services:
       DISCOVERY_TOPIC: homeassistant
       DISCOVERY_DEVICE_NAME: TheengsGateway
       DISCOVERY_FILTER: "[IBEACON,GAEN,MS-CDP]"
+      DISCOVERY_DIAGNOSTIC: true
       SCANNING_MODE: active
       ADAPTER: hci0
       TIME_SYNC: "[]"
@@ -123,6 +124,7 @@ docker run --rm \
     -e DISCOVERY_TOPIC=homeassistant \
     -e DISCOVERY_DEVICE_NAME=TheengsGateway \
     -e DISCOVERY_FILTER="[IBEACON]" \
+    -e DISCOVERY_DIAGNOSTIC=true \
     -e SCANNING_MODE=active \
     -e ADAPTER=hci0 \
     -e TIME_SYNC="[]" \

--- a/chroot/opt/venv/start.sh
+++ b/chroot/opt/venv/start.sh
@@ -118,6 +118,13 @@ if hasvalue $HASS_DISCOVERY; then
 	fi
 fi
 
+if hasvalue $DISCOVERY_DIAGNOSTIC; then
+	if ! [[ $DISCOVERY_DIAGNOSTIC =~ (true|false) ]]; then
+		echo "WARNING : Wrong value for DISCOVERY_DIAGNOSTIC environment variable, will use default - false"
+		DISCOVERY_DIAGNOSTIC=false
+	fi
+fi
+
 if hasvalue $PASSIVE_SCAN; then
 	# Deprecation warning, this was written before 0.5.0 was released , will use SCANNIN_MODE in future
 	echo "PASSIVE_SCAN : Deprecated environment variable, this variable will be removed in future versions, please use SCANNING_MODE=active|passive"
@@ -216,6 +223,7 @@ echo "Creating config at $CONFIG ..."
     "discovery_topic": "${DISCOVERY_TOPIC:-homeassistant/sensor}",
     "discovery_device_name": "${DISCOVERY_DEVICE_NAME:-TheengsGateway}",
     "discovery_filter": "${DISCOVERY_FILTER:-[IBEACON]}",
+    "discovery_diagnostic": ${DISCOVERY_DIAGNOSTIC:-false},
     "scanning_mode": "${SCANNING_MODE:-active}",
     "adapter": "${ADAPTER:-hci0}",
     "time_sync": "${TIME_SYNC:-[]}",

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       DISCOVERY_TOPIC: homeassistant
       DISCOVERY_DEVICE_NAME: TheengsGateway
       DISCOVERY_FILTER: "[IBEACON]"
+      DISCOVERY_DIAGNOSTIC: true
       SCANNING_MODE: active
       ADAPTER: hci0
       BINDKEYS: "{}"


### PR DESCRIPTION
- added `DISCOVERY_DIAGNOSTIC` environment variable to `start.sh`, validated like the other booleans
- added it to the README examples and `examples/docker-compose.yml`

This sets `discovery_diagnostic`, the option added in theengs/gateway#325, which marks battery, voltage and RSSI entities with Home Assistant's diagnostic entity category so they group separately from a device's main readings. Without this there's no way to reach it from Docker except the undocumented `PARAMS` passthrough.

It defaults to `false`, matching the gateway's own default for minimal disruption to existing installations. The documented examples set it to `true` on purpose, to encourage usage of the option on new installs.

Nothing breaks if this is released early, but it does document an option that won't actually exist until a gateway version that supports `discovery_diagnostic` is released. Should be merged around the same time that the `TheengsGateway==1.7.5` pin is bumped to a version with this support.

[tested on amd64 against a build of theengs/gateway#325 with start.sh pulled in from this branch: works as expected with the variable unset, set to an invalid value, and correctly set to true/false]
