### PR TITLE
Redact MQTT password from startup logs

### DIFF
--- a/chroot/opt/venv/start.sh
+++ b/chroot/opt/venv/start.sh
@@ -254,7 +254,7 @@ EOF
     echo "}"
 } > $CONFIG
 
-cat $CONFIG
+sed 's/"pass": "[^"]*"/"pass": "***"/' "$CONFIG"
 
 
 python3 -m TheengsGateway $PARAMS


### PR DESCRIPTION
## Summary

Redact the MQTT password when printing the generated Gateway configuration at startup.

The configuration file still contains the real password for Gateway use, while the logged representation shows `"pass": "***"`.

## Validation

- `bash -n chroot/opt/venv/start.sh`
- Container smoke test with a dummy MQTT password
- Gateway startup confirmed with the password redacted in logs
